### PR TITLE
Tootbot 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 media/
 cache.csv
-mastodon.secret
+*.secret
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ media/
 cache.csv
 *.secret
 .vscode/
+__pycache__/
+*.pyc

--- a/config.ini
+++ b/config.ini
@@ -27,22 +27,9 @@ MediaPostsOnly: false
 
 # Twitter settings (leave blank to disable Twitter posting)
 [Twitter]
-AccessToken: 
-AccessTokenSecret: 
-ConsumerKey: 
-ConsumerSecret: 
+PostToTwitter: true
 
 # Mastodon settings (leave blank to disable Mastodon posting)
 [Mastodon]
 # Name of instance to log into (examples: 'mastodon.social', 'mstn.io', etc.)
 InstanceDomain: 
-
-# Reddit API settings
-[Reddit]
-Agent: 
-ClientSecret: 
-
-# Imgur API settings
-[Imgur]
-ClientID: 
-ClientSecret: 

--- a/config.ini
+++ b/config.ini
@@ -23,6 +23,7 @@ ConsumerSecret:
 # Place your Mastodon info here (leave blank to disable Mastodon posting)
 [Mastodon]
 InstanceDomain: 
+PostVisibility: unlisted
 
 # Place your Reddit API info here
 [Reddit]

--- a/config.ini
+++ b/config.ini
@@ -25,11 +25,12 @@ MediaFolder: media
 # Links from Gfycat, Giphy, Imgur, i.redd.it, and i.reddituploads.com are currently supported
 MediaPostsOnly: false
 
-# Twitter settings (leave blank to disable Twitter posting)
+# Twitter settings
 [Twitter]
+# Enable or disable Twitter posting
 PostToTwitter: true
 
-# Mastodon settings (leave blank to disable Mastodon posting)
+# Mastodon settings
 [Mastodon]
-# Name of instance to log into (examples: 'mastodon.social', 'mstn.io', etc.)
+# Name of instance to log into (example: mastodon.social), leave blank to disable Mastodon posting
 InstanceDomain: 

--- a/config.ini
+++ b/config.ini
@@ -1,36 +1,54 @@
+# This is the config file for Tootbot! You must restart the bot for any changes to take effect.
+
 # General settings
 [BotSettings]
+# File name for the cache spreadsheet (default is 'cache.csv')
 CacheFile: cache.csv
-MediaFolder: media
-DelayBetweenTweets: 600
+# Minimum delay between social media posts, in seconds (default is '600')
+DelayBetweenPosts: 600
+# Minimum position of post on subreddit front page that the bot will look at (default is '10')
 PostLimit: 10
+# Name of subreddit to take posts from (example: 'gaming')
+# Multiple subreddits can be used like this: 'gaming+funny+news'
 SubredditToMonitor: 
+# Allow NSFW Reddit posts to be posted by the bot
+# NSFW posts will be hidden behind a content warning on Mastodon, regardless of this setting
 NSFWPostsAllowed: false
+# Allow Reddit self-posts to be posted by the bot
 SelfPostsAllowed: true
 
 # Settings related to media attachments
 [MediaSettings]
+# Folder name for media downloads (default is 'media')
 MediaFolder: media
+# Set the bot to only post Reddit posts that directly link to media
+# Links from Gfycat, Giphy, Imgur, i.redd.it, and i.reddituploads.com are currently supported
 MediaPostsOnly: false
 
-# Place your Twitter API keys here (leave blank to disable Twitter posting)
+# Twitter settings (leave blank to disable Twitter posting)
 [Twitter]
 AccessToken: 
 AccessTokenSecret: 
 ConsumerKey: 
 ConsumerSecret: 
 
-# Place your Mastodon info here (leave blank to disable Mastodon posting)
+# Mastodon settings (leave blank to disable Mastodon posting)
 [Mastodon]
+# Name of instance to log into (examples: 'mastodon.social', 'mstn.io', etc.)
 InstanceDomain: 
+# Visibility setting for posts (default is 'unlisted')
+# 'direct' - Post will be visible only to mentioned users
+# 'private' - Post will be visible only to followers
+# 'unlisted' - Post will be public but not appear on the public timeline
+# 'public' - Post will be public
 PostVisibility: unlisted
 
-# Place your Reddit API info here
+# Reddit API settings
 [Reddit]
 Agent: 
 ClientSecret: 
 
-# Place your Imgur API info here
+# Imgur API settings
 [Imgur]
 ClientID: 
 ClientSecret: 

--- a/config.ini
+++ b/config.ini
@@ -36,12 +36,6 @@ ConsumerSecret:
 [Mastodon]
 # Name of instance to log into (examples: 'mastodon.social', 'mstn.io', etc.)
 InstanceDomain: 
-# Visibility setting for posts (default is 'unlisted')
-# 'direct' - Post will be visible only to mentioned users
-# 'private' - Post will be visible only to followers
-# 'unlisted' - Post will be public but not appear on the public timeline
-# 'public' - Post will be public
-PostVisibility: unlisted
 
 # Reddit API settings
 [Reddit]

--- a/getmedia.py
+++ b/getmedia.py
@@ -1,0 +1,139 @@
+import os
+import sys
+import configparser
+from gfycat.client import GfycatClient
+from imgurpython import ImgurClient
+from PIL import Image
+import urllib.request
+import requests
+import re
+
+# Function for downloading images from a URL to media folder
+def save_file(img_url, file_path):
+	resp = requests.get(img_url, stream=True)
+	if resp.status_code == 200:
+		with open(file_path, 'wb') as image_file:
+			for chunk in resp:
+				image_file.write(chunk)
+		# Return the path of the image, which is always the same since we just overwrite images
+		image_file.close()
+		return file_path
+	else:
+		print('[EROR] File failed to download. Status code: ' + str(resp.status_code))
+		return
+
+# Function for obtaining direct image URLs from popular image hosts
+def get_media(img_url, IMGUR_CLIENT, IMGUR_CLIENT_SECRET):
+  # Make sure config file exists
+  try:
+      config = configparser.ConfigParser()
+      config.read('config.ini')
+  except BaseException as e:
+      print ('[EROR] Error while reading config file:', str(e))
+      sys.exit()
+  # Make sure media folder exists
+  IMAGE_DIR = config['MediaSettings']['MediaFolder']
+  if not os.path.exists(IMAGE_DIR):
+      os.makedirs(IMAGE_DIR)
+      print ('[ OK ] ' + IMAGE_DIR + ' folder not found, created a new one')
+  # Download and save the linked image
+  if any(s in img_url for s in ('i.redd.it', 'i.reddituploads.com')): # Reddit links
+    file_name = os.path.basename(urllib.parse.urlsplit(img_url).path)
+    file_extension = os.path.splitext(img_url)[-1].lower()
+    # Fix for issue with i.reddituploads.com links not having a file extension in the URL
+    if not file_extension:
+      file_extension += '.jpg'
+      file_name += '.jpg'
+      img_url += '.jpg'
+    # Grab the GIF versions of .GIFV links
+    # When Tweepy adds support for video uploads, we can use grab the MP4 versions
+    if (file_extension == '.gifv'):
+      file_extension = file_extension.replace('.gifv', '.gif')
+      file_name = file_name.replace('.gifv', '.gif')
+      img_url = img_url.replace('.gifv', '.gif')
+    # Download the file
+    file_path = IMAGE_DIR + '/' + file_name
+    print('[ OK ] Downloading file at URL ' + img_url + ' to ' + file_path + ', file type identified as ' + file_extension)
+    img = save_file(img_url, file_path)
+    return img
+  elif ('imgur.com' in img_url): # Imgur
+    try:
+      client = ImgurClient(IMGUR_CLIENT, IMGUR_CLIENT_SECRET)
+    except BaseException as e:
+      print ('[EROR] Error while authenticating with Imgur:', str(e))	
+      return
+    # Working demo of regex: https://regex101.com/r/G29uGl/2
+    regex = r"(?:.*)imgur\.com(?:\/gallery\/|\/a\/|\/)(.*?)(?:\/.*|\.|$)"
+    m = re.search(regex, img_url, flags=0)
+    if m:
+      # Get the Imgur image/gallery ID
+      id = m.group(1)
+      if any(s in img_url for s in ('/a/', '/gallery/')): # Gallery links
+        images = client.get_album_images(id)
+        # Only the first image in a gallery is used
+        imgur_url = images[0].link
+      else: # Single image
+        imgur_url = client.get_image(id).link
+      # If the URL is a GIFV link, change it to a GIF
+      file_extension = os.path.splitext(imgur_url)[-1].lower()
+      if (file_extension == '.gifv'):
+        file_extension = file_extension.replace('.gifv', '.gif')
+        img_url = imgur_url.replace('.gifv', '.gif')
+      # Download the image
+      file_path = IMAGE_DIR + '/' + id + file_extension
+      print('[ OK ] Downloading Imgur image at URL ' + imgur_url + ' to ' + file_path)
+      imgur_file = save_file(imgur_url, file_path)
+      # Imgur will sometimes return a single-frame thumbnail instead of a GIF, so we need to check for this
+      if (file_extension == '.gif'):
+        # Open the file using the Pillow library
+        img = Image.open(imgur_file)
+        # Get the MIME type
+        mime = Image.MIME[img.format]
+        if (mime == 'image/gif'):
+          # Image is indeed a GIF, so it can be posted
+          img.close()
+          return imgur_file
+        else:
+          # Image is not actually a GIF, so don't post it
+          print('[EROR] Imgur has not processed a GIF version of this link, so it can not be posted')
+          img.close()
+          # Delete the image
+          try:
+            os.remove(imgur_file)
+          except BaseException as e:
+            print ('[EROR] Error while deleting media file:', str(e))
+          return
+      else:
+        return imgur_file
+    else:
+      print('[EROR] Could not identify Imgur image/gallery ID in this URL:', img_url)
+      return
+  elif ('gfycat.com' in img_url): # Gfycat
+    gfycat_name = os.path.basename(urllib.parse.urlsplit(img_url).path)
+    client = GfycatClient()
+    gfycat_info = client.query_gfy(gfycat_name)
+    # Download the 2MB version because Tweepy has a 3MB upload limit for GIFs
+    gfycat_url = gfycat_info['gfyItem']['max2mbGif']
+    file_path = IMAGE_DIR + '/' + gfycat_name + '.gif'
+    print('[ OK ] Downloading Gfycat at URL ' + gfycat_url + ' to ' + file_path)
+    gfycat_file = save_file(gfycat_url, file_path)
+    return gfycat_file
+  elif ('giphy.com' in img_url): # Giphy
+    # Working demo of regex: https://regex101.com/r/o8m1kA/2
+    regex = r"https?://((?:.*)giphy\.com/media/|giphy.com/gifs/|i.giphy.com/)(.*-)?(\w+)(/|\n)"
+    m = re.search(regex, img_url, flags=0)
+    if m:
+      # Get the Giphy ID
+      id = m.group(3)
+      # Download the 2MB version because Tweepy has a 3MB upload limit for GIFs
+      giphy_url = 'https://media.giphy.com/media/' + id + '/giphy-downsized.gif'
+      file_path = IMAGE_DIR + '/' + id + '-downsized.gif'
+      print('[ OK ] Downloading Giphy at URL ' + giphy_url + ' to ' + file_path)
+      giphy_file = save_file(giphy_url, file_path)
+      return giphy_file
+    else:
+      print('[EROR] Could not identify Giphy ID in this URL:', img_url)
+      return
+  else:
+    # Silently fail when there isn't a media attachment to download
+    return

--- a/getmedia.py
+++ b/getmedia.py
@@ -7,6 +7,12 @@ from PIL import Image
 import urllib.request
 import requests
 import re
+import hashlib
+
+# Function for opening file as string of bytes
+def file_as_bytes(file):
+  with file:
+    return file.read()
 
 # Function for downloading images from a URL to media folder
 def save_file(img_url, file_path):
@@ -130,7 +136,14 @@ def get_media(img_url, IMGUR_CLIENT, IMGUR_CLIENT_SECRET):
       file_path = IMAGE_DIR + '/' + id + '-downsized.gif'
       print('[ OK ] Downloading Giphy at URL ' + giphy_url + ' to ' + file_path)
       giphy_file = save_file(giphy_url, file_path)
-      return giphy_file
+      # Check the hash to make sure it's not a GIF saying "This content is not available"
+      # More info: https://github.com/corbindavenport/tootbot/issues/8
+      hash = hashlib.md5(file_as_bytes(open(giphy_file, 'rb'))).hexdigest()
+      if (hash == '59a41d58693283c72d9da8ae0561e4e5'):
+        print('[EROR] Giphy has not processed a downsized GIF version of this link, so it can not be posted')
+        return
+      else:
+        return giphy_file
     else:
       print('[EROR] Could not identify Giphy ID in this URL:', img_url)
       return

--- a/tootbot.py
+++ b/tootbot.py
@@ -7,6 +7,7 @@ import csv
 import configparser
 import urllib.parse
 import sys
+from imgurpython import ImgurClient
 from glob import glob
 import distutils.core
 import itertools
@@ -34,12 +35,12 @@ def tweet_creator(subreddit_info):
 			if len(submission.title) < twitter_max_title_length:
 				twitter_post = submission.title + ' ' + submission.shortlink
 			else:
-				twitter_post = submission.title[:max_title_length] + '... ' + submission.shortlink
+				twitter_post = submission.title[:twitter_max_title_length] + '... ' + submission.shortlink
 			# Create contents of the Mastodon post
 			if len(submission.title) < mastodon_max_title_length:
 				mastodon_post = submission.title + ' ' + submission.shortlink
 			else:
-				mastodon_post = submission.title[:max_title_length] + '... ' + submission.shortlink
+				mastodon_post = submission.title[:mastodon_max_title_length] + '... ' + submission.shortlink
 			# Create dict
 			post_dict[submission.id] = [twitter_post,mastodon_post,submission.url, submission.id, submission.over_18]
 	return post_dict

--- a/tootbot.py
+++ b/tootbot.py
@@ -231,16 +231,16 @@ def make_post(post_dict):
 							media = mastodon.media_post(file_path, mime_type=None)
 							# Add NSFW warning for Reddit posts marked as NSFW
 							if (post_dict[post][4] == True):
-								toot = mastodon.status_post(post_dict[post][1],media_ids=[media],visibility=MASTODON_POST_VISIBILITY,spoiler_text='NSFW')
+								toot = mastodon.status_post(post_dict[post][1],media_ids=[media],spoiler_text='NSFW')
 							else:	
-								toot = mastodon.status_post(post_dict[post][1],media_ids=[media],visibility=MASTODON_POST_VISIBILITY)
+								toot = mastodon.status_post(post_dict[post][1],media_ids=[media])
 						else:
 							print ('[ OK ] Posting this on Mastodon account:', post_dict[post][1])
 							# Add NSFW warning for Reddit posts marked as NSFW
 							if (post_dict[post][4] == True):
-								toot = mastodon.status_post(post_dict[post][1],visibility=MASTODON_POST_VISIBILITY,spoiler_text='NSFW')
+								toot = mastodon.status_post(post_dict[post][1],spoiler_text='NSFW')
 							else:	
-								toot = mastodon.status_post(post_dict[post][1],visibility=MASTODON_POST_VISIBILITY)
+								toot = mastodon.status_post(post_dict[post][1])
 						# Log the toot
 						log_post(post_id, toot["url"])
 					except BaseException as e:
@@ -300,7 +300,6 @@ CONSUMER_KEY = config['Twitter']['ConsumerKey']
 CONSUMER_SECRET = config['Twitter']['ConsumerSecret']
 # Mastodon info
 MASTODON_INSTANCE_DOMAIN = config['Mastodon']['InstanceDomain']
-MASTODON_POST_VISIBILITY = config['Mastodon']['PostVisibility']
 # Reddit API keys
 REDDIT_AGENT = config['Reddit']['Agent']
 REDDIT_CLIENT_SECRET = config['Reddit']['ClientSecret']

--- a/tootbot.py
+++ b/tootbot.py
@@ -193,9 +193,6 @@ def log_post(id, post_url):
 	cache.close()
 
 def make_post(post_dict):
-	auth = tweepy.OAuthHandler(CONSUMER_KEY, CONSUMER_SECRET)
-	auth.set_access_token(ACCESS_TOKEN, ACCESS_TOKEN_SECRET)
-	api = tweepy.API(auth)
 	for post in post_dict:
 		# Grab post details from dictionary
 		post_id = post_dict[post][3]
@@ -204,7 +201,7 @@ def make_post(post_dict):
 			# Make sure the post contains media (if it doesn't, then file_path would be blank)
 			if (((MEDIA_POSTS_ONLY is True) and (file_path)) or (MEDIA_POSTS_ONLY is False)):
 				# Post on Twitter
-				if ACCESS_TOKEN:
+				if POST_TO_TWITTER:
 					try:
 						auth = tweepy.OAuthHandler(CONSUMER_KEY, CONSUMER_SECRET)
 						auth.set_access_token(ACCESS_TOKEN, ACCESS_TOKEN_SECRET)
@@ -364,7 +361,7 @@ if POST_TO_TWITTER is True:
 		ACCESS_TOKEN = twitter_config['Twitter']['AccessToken']
 		ACCESS_TOKEN_SECRET = twitter_config['Twitter']['AccessTokenSecret']
 		CONSUMER_KEY = twitter_config['Twitter']['ConsumerKey']
-		CONSUMER_SECRET = twitter_config['Twitter']['ConsumerKeySecret']
+		CONSUMER_SECRET = twitter_config['Twitter']['ConsumerSecret']
 		try:
 			# Make sure authentication is working
 			auth = tweepy.OAuthHandler(CONSUMER_KEY, CONSUMER_SECRET)
@@ -384,7 +381,6 @@ if POST_TO_TWITTER is True:
 		ACCESS_TOKEN_SECRET = ''.join(input('[ .. ] Enter access token secret for Twitter account: ').split())
 		CONSUMER_KEY = ''.join(input('[ .. ] Enter consumer key for Twitter account: ').split())
 		CONSUMER_SECRET = ''.join(input('[ .. ] Enter consumer secret for Twitter account: ').split())
-		print (ACCESS_TOKEN, ACCESS_TOKEN_SECRET, CONSUMER_KEY, CONSUMER_SECRET)
 		print ('[ OK ] Attempting to log in to Twitter...')
 		try:
 			# Make sure authentication is working
@@ -456,7 +452,7 @@ if MASTODON_INSTANCE_DOMAIN:
 # Set the command line window title on Windows
 if (os.name == 'nt'):
 	try:
-		if ACCESS_TOKEN and MASTODON_INSTANCE_DOMAIN:
+		if POST_TO_TWITTER and MASTODON_INSTANCE_DOMAIN:
 			# Set title with both Twitter and Mastodon usernames
 			# Get Twitter username
 			twitter_username = twitter.me().screen_name
@@ -464,7 +460,7 @@ if (os.name == 'nt'):
 			masto_username = mastodon.account_verify_credentials()['username']
 			# Set window title
 			title = twitter_username + '@twitter.com and ' + masto_username + '@' + MASTODON_INSTANCE_DOMAIN + ' - Tootbot'
-		elif ACCESS_TOKEN:
+		elif POST_TO_TWITTER:
 			# Set title with just Twitter username
 			twitter_username = twitter.me().screen_name
 			# Set window title

--- a/tootbot.py
+++ b/tootbot.py
@@ -141,7 +141,7 @@ try:
 	with urllib.request.urlopen("https://raw.githubusercontent.com/corbindavenport/tootbot/update-check/current-version.txt") as url:
 		s = url.read()
 		new_version = s.decode("utf-8").rstrip()
-		current_version = 1.0 # Current version of script
+		current_version = 2.0 # Current version of script
 		if (current_version < float(new_version)):
 			print('[WARN] A new version of Tootbot (' + str(new_version) + ') is available! (you have ' + str(current_version) + ')')
 			print ('[WARN] Get the latest update from here: https://github.com/corbindavenport/tootbot/releases')

--- a/tootbot.py
+++ b/tootbot.py
@@ -285,7 +285,7 @@ except BaseException as e:
 	sys.exit()
 # General settings
 CACHE_CSV = config['BotSettings']['CacheFile']
-DELAY_BETWEEN_TWEETS = int(config['BotSettings']['DelayBetweenTweets'])
+DELAY_BETWEEN_TWEETS = int(config['BotSettings']['DelayBetweenPosts'])
 POST_LIMIT = int(config['BotSettings']['PostLimit'])
 SUBREDDIT_TO_MONITOR = config['BotSettings']['SubredditToMonitor']
 NSFW_POSTS_ALLOWED = bool(distutils.util.strtobool(config['BotSettings']['NSFWPostsAllowed']))

--- a/tootbot.py
+++ b/tootbot.py
@@ -301,11 +301,38 @@ CONSUMER_SECRET = config['Twitter']['ConsumerSecret']
 # Mastodon info
 MASTODON_INSTANCE_DOMAIN = config['Mastodon']['InstanceDomain']
 # Reddit API keys
-REDDIT_AGENT = config['Reddit']['Agent']
-REDDIT_CLIENT_SECRET = config['Reddit']['ClientSecret']
+#REDDIT_AGENT = config['Reddit']['Agent']
+#REDDIT_CLIENT_SECRET = config['Reddit']['ClientSecret']
 # Imgur API keys
 IMGUR_CLIENT = config['Imgur']['ClientID']
 IMGUR_CLIENT_SECRET = config['Imgur']['ClientSecret']
+# Setup Reddit access if it hasn't been done already
+if not os.path.exists('reddit.secret'):
+	print ('[WARN] API keys for Reddit not found. Please enter them below (see wiki if you need help).')
+	REDDIT_AGENT = input("[ .. ] Enter Reddit agent: ")
+	REDDIT_CLIENT_SECRET = input("[ .. ] Enter Reddit client secret: ")
+	# Make sure authentication is working
+	try:
+		reddit_client = praw.Reddit(user_agent='Tootbot', client_id=REDDIT_AGENT, client_secret=REDDIT_CLIENT_SECRET)
+		test = reddit_client.subreddit('announcements')
+		# It worked, so save the keys to a file
+		reddit_config = configparser.ConfigParser()
+		reddit_config['Reddit'] = {
+			'Agent': REDDIT_AGENT,
+			'ClientSecret': REDDIT_CLIENT_SECRET
+		}
+		with open('reddit.secret', 'w') as f:
+			reddit_config.write(f)
+		f.close()
+	except BaseException as e:
+		print ('[EROR] Error while logging into Reddit:', str(e))
+		print ('[EROR] Tootbot cannot continue, now shutting down')
+		exit()
+else:
+	reddit_config = configparser.ConfigParser()
+	reddit_config.read('reddit.secret')
+	REDDIT_AGENT = reddit_config['Reddit']['Agent']
+	REDDIT_CLIENT_SECRET = reddit_config['Reddit']['ClientSecret']
 # Log into Twitter if enabled in settings
 if ACCESS_TOKEN:
 	try:

--- a/tootbot.py
+++ b/tootbot.py
@@ -306,8 +306,8 @@ if MASTODON_INSTANCE_DOMAIN:
 				to_file = 'mastodon.secret'
 			)
 			# Make sure authentication is working
-			username = mastodon.account_verify_credentials()['username']
-			print ('[ OK ] Sucessfully authenticated on ' + MASTODON_INSTANCE_DOMAIN + ' as @' + username + ', login information now stored in mastodon.secret file')
+			masto_username = mastodon.account_verify_credentials()['username']
+			print ('[ OK ] Sucessfully authenticated on ' + MASTODON_INSTANCE_DOMAIN + ' as @' + masto_username + ', login information now stored in mastodon.secret file')
 		except BaseException as e:
 			print ('[EROR] Error while logging into Mastodon:', str(e))
 			print ('[EROR] Tootbot cannot continue, now shutting down')
@@ -328,28 +328,22 @@ if MASTODON_INSTANCE_DOMAIN:
 			exit()
 # Set the command line window title on Windows
 if (os.name == 'nt'):
-	try:
-		if POST_TO_TWITTER and MASTODON_INSTANCE_DOMAIN:
+  try:
+    if POST_TO_TWITTER and MASTODON_INSTANCE_DOMAIN:
 			# Set title with both Twitter and Mastodon usernames
-			# Get Twitter username
-			twitter_username = twitter.me().screen_name
-			# Get Mastodon username
-			masto_username = mastodon.account_verify_credentials()['username']
-			# Set window title
-			title = twitter_username + '@twitter.com and ' + masto_username + '@' + MASTODON_INSTANCE_DOMAIN + ' - Tootbot'
-		elif POST_TO_TWITTER:
-			# Set title with just Twitter username
-			twitter_username = twitter.me().screen_name
-			# Set window title
-			title = '@' + twitter_username + ' - Tootbot'
-		elif MASTODON_INSTANCE_DOMAIN:
+      twitter_username = twitter.me().screen_name
+      masto_username = mastodon.account_verify_credentials()['username']
+      os.system('title ' + twitter_username + '@twitter.com and ' + masto_username + '@' + MASTODON_INSTANCE_DOMAIN + ' - Tootbot')
+    elif POST_TO_TWITTER:
+      # Set title with just Twitter username
+      twitter_username = twitter.me().screen_name
+      os.system('title ' + '@' + twitter_username + ' - Tootbot')
+    elif MASTODON_INSTANCE_DOMAIN:
 			# Set title with just Mastodon username
-			masto_username = mastodon.account_verify_credentials()['username']
-			# Set window title
-			title = masto_username + '@' + MASTODON_INSTANCE_DOMAIN + ' - Tootbot'
-	except :
-		title = 'Tootbot'
-		os.system('title ' + title)
+      masto_username = mastodon.account_verify_credentials()['username']
+      os.system('title ' + masto_username + '@' + MASTODON_INSTANCE_DOMAIN + ' - Tootbot')
+  except:
+    os.system('title Tootbot')
 # Run the main script
 while True:
 	# Make sure logging file and media directory exists

--- a/tootbot.py
+++ b/tootbot.py
@@ -300,13 +300,7 @@ CONSUMER_KEY = config['Twitter']['ConsumerKey']
 CONSUMER_SECRET = config['Twitter']['ConsumerSecret']
 # Mastodon info
 MASTODON_INSTANCE_DOMAIN = config['Mastodon']['InstanceDomain']
-# Reddit API keys
-#REDDIT_AGENT = config['Reddit']['Agent']
-#REDDIT_CLIENT_SECRET = config['Reddit']['ClientSecret']
-# Imgur API keys
-IMGUR_CLIENT = config['Imgur']['ClientID']
-IMGUR_CLIENT_SECRET = config['Imgur']['ClientSecret']
-# Setup Reddit access if it hasn't been done already
+# Setup and verify Reddit access
 if not os.path.exists('reddit.secret'):
 	print ('[WARN] API keys for Reddit not found. Please enter them below (see wiki if you need help).')
 	REDDIT_AGENT = input("[ .. ] Enter Reddit agent: ")
@@ -329,10 +323,39 @@ if not os.path.exists('reddit.secret'):
 		print ('[EROR] Tootbot cannot continue, now shutting down')
 		exit()
 else:
+	# Read API keys from secret file
 	reddit_config = configparser.ConfigParser()
 	reddit_config.read('reddit.secret')
 	REDDIT_AGENT = reddit_config['Reddit']['Agent']
 	REDDIT_CLIENT_SECRET = reddit_config['Reddit']['ClientSecret']
+# Setup and verify Imgur access
+if not os.path.exists('imgur.secret'):
+	print ('[WARN] API keys for Imgur not found. Please enter them below (see wiki if you need help).')
+	IMGUR_CLIENT = input("[ .. ] Enter Imgur client ID: ")
+	IMGUR_CLIENT_SECRET = input("[ .. ] Enter Imgur client secret: ")
+	# Make sure authentication is working
+	try:
+		imgur_client = ImgurClient(IMGUR_CLIENT, IMGUR_CLIENT_SECRET)
+		test_gallery = imgur_client.get_album('dqOyj')
+		# It worked, so save the keys to a file
+		imgur_config = configparser.ConfigParser()
+		imgur_config['Imgur'] = {
+			'ClientID': IMGUR_CLIENT,
+			'ClientSecret': IMGUR_CLIENT_SECRET
+		}
+		with open('imgur.secret', 'w') as f:
+			imgur_config.write(f)
+		f.close()
+	except BaseException as e:
+		print ('[EROR] Error while logging into Imgur:', str(e))
+		print ('[EROR] Tootbot cannot continue, now shutting down')
+		exit()
+else:
+	# Read API keys from secret file
+	imgur_config = configparser.ConfigParser()
+	imgur_config.read('imgur.secret')
+	IMGUR_CLIENT = imgur_config['Imgur']['ClientID']
+	IMGUR_CLIENT_SECRET = imgur_config['Imgur']['ClientSecret']
 # Log into Twitter if enabled in settings
 if ACCESS_TOKEN:
 	try:


### PR DESCRIPTION
* API keys for Twitter, Imgur, and Reddit are now stored in .secret files
* Added `PostToTwitter` setting to disable or enable Twitter posting
* Fixed bug where posting to Mastodon would fail
* Fixed bug where Tootbot would post "This content is not available" on some Giphy links (#8)
* Renamed `DelayBetweenTweets` setting to `DelayBetweenPosts`
* Added comments in `config.ini` that explain each setting

**Update instructions:**

If you are updating from Tootbot v1.0, there are a few minor tasks you must do, or else the updated version will fail:

1. Add `PostToTwitter: true` to the `[Twitter]` section of the `config.ini` file. If your bot does not post to Twitter, set that to `false`.
2. Find the `DelayBetweenTweets` setting in `config.ini`, and rename it to `DelayBetweenPosts`.

Tootbot v2.0 stores API keys in separate files, instead of in the `config.ini` file. When running the updated version for the first time, you will be asked for all your API keys again. This will only happen once, and you can just copy and paste them from your `config.ini` file.