### PR TITLE
Tootbot 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a Python bot that looks up posts from specified subreddits and automatic
 
 * Tootbot can post to both Twitter and [Mastodon](https://joinmastodon.org/)
 * Tootbot can either run locally, or in the cloud with a free Heroku account
-* Media from direct links, Gfycat, Imgur, Reddit, and Giphy is automatically attached in the social media post (unless the video file is too large or cannot be converted into a GIF)
+* Media from direct links, Gfycat, Imgur, Reddit, and Giphy is automatically attached in the social media post
 * Links that do not contain media can be skipped, ideal for meme accounts like [@badreactiongifs](https://twitter.com/badreactiongifs)
 * NSFW content, spoilers, and self-posts can be filtered
 * Tootbot can monitor multiple subreddits at once

--- a/getmedia.py
+++ b/getmedia.py
@@ -11,278 +11,299 @@ import re
 import hashlib
 
 # Function for opening file as string of bytes
+
 def file_as_bytes(file):
-  with file:
-    return file.read()
+    with file:
+        return file.read()
 
 # Function for downloading images from a URL to media folder
+
 def save_file(img_url, file_path):
-	resp = requests.get(img_url, stream=True)
-	if resp.status_code == 200:
-		with open(file_path, 'wb') as image_file:
-			for chunk in resp:
-				image_file.write(chunk)
-		# Return the path of the image, which is always the same since we just overwrite images
-		image_file.close()
-		return file_path
-	else:
-		print('[EROR] File failed to download. Status code: ' + str(resp.status_code))
-		return
+    resp = requests.get(img_url, stream=True)
+    if resp.status_code == 200:
+        with open(file_path, 'wb') as image_file:
+            for chunk in resp:
+                image_file.write(chunk)
+        # Return the path of the image, which is always the same since we just overwrite images
+        image_file.close()
+        return file_path
+    else:
+        print('[EROR] File failed to download. Status code: ' +
+              str(resp.status_code))
+        return
 
 # Function for obtaining static images and GIFs from popular image hosts
+
 def get_media(img_url, IMGUR_CLIENT, IMGUR_CLIENT_SECRET):
   # Make sure config file exists
   try:
       config = configparser.ConfigParser()
       config.read('config.ini')
   except BaseException as e:
-      print ('[EROR] Error while reading config file:', str(e))
+      print('[EROR] Error while reading config file:', str(e))
       sys.exit()
   # Make sure media folder exists
   IMAGE_DIR = config['MediaSettings']['MediaFolder']
   if not os.path.exists(IMAGE_DIR):
       os.makedirs(IMAGE_DIR)
-      print ('[ OK ] Media folder not found, created a new one')
+      print('[ OK ] Media folder not found, created a new one')
   # Download and save the linked image
-  if any(s in img_url for s in ('i.redd.it', 'i.reddituploads.com')): # Reddit-hosted images
-    file_name = os.path.basename(urllib.parse.urlsplit(img_url).path)
-    file_extension = os.path.splitext(img_url)[-1].lower()
-    # Fix for issue with i.reddituploads.com links not having a file extension in the URL
-    if not file_extension:
-      file_extension += '.jpg'
-      file_name += '.jpg'
-      img_url += '.jpg'
-    # Download the file
-    file_path = IMAGE_DIR + '/' + file_name
-    print('[ OK ] Downloading file at URL ' + img_url + ' to ' + file_path + ', file type identified as ' + file_extension)
-    img = save_file(img_url, file_path)
-    return img
-  elif ('imgur.com' in img_url): # Imgur
-    try:
-      client = ImgurClient(IMGUR_CLIENT, IMGUR_CLIENT_SECRET)
-    except BaseException as e:
-      print ('[EROR] Error while authenticating with Imgur:', str(e))	
-      return
-    # Working demo of regex: https://regex101.com/r/G29uGl/2
-    regex = r"(?:.*)imgur\.com(?:\/gallery\/|\/a\/|\/)(.*?)(?:\/.*|\.|$)"
-    m = re.search(regex, img_url, flags=0)
-    if m:
-      # Get the Imgur image/gallery ID
-      id = m.group(1)
-      if any(s in img_url for s in ('/a/', '/gallery/')): # Gallery links
-        images = client.get_album_images(id)
-        # Only the first image in a gallery is used
-        imgur_url = images[0].link
-      else: # Single image
-        imgur_url = client.get_image(id).link
-      # If the URL is a GIFV or MP4 link, change it to the GIF version
-      file_extension = os.path.splitext(imgur_url)[-1].lower()
-      if (file_extension == '.gifv'):
-        file_extension = file_extension.replace('.gifv', '.gif')
-        imgur_url = imgur_url.replace('.gifv', '.gif')
-      elif (file_extension == '.mp4'):
-        file_extension = file_extension.replace('.mp4', '.gif')
-        imgur_url = imgur_url.replace('.mp4', '.gif')
-      # Download the image
-      file_path = IMAGE_DIR + '/' + id + file_extension
-      print('[ OK ] Downloading Imgur image at URL ' + imgur_url + ' to ' + file_path)
-      imgur_file = save_file(imgur_url, file_path)
-      # Imgur will sometimes return a single-frame thumbnail instead of a GIF, so we need to check for this
-      if (file_extension == '.gif'):
-        # Open the file using the Pillow library
-        img = Image.open(imgur_file)
-        # Get the MIME type
-        mime = Image.MIME[img.format]
-        if (mime == 'image/gif'):
-          # Image is indeed a GIF, so it can be posted
-          img.close()
-          return imgur_file
-        else:
-          # Image is not actually a GIF, so don't post it
-          print('[EROR] Imgur has not processed a GIF version of this link, so it can not be posted')
-          img.close()
-          # Delete the image
-          try:
-            os.remove(imgur_file)
-          except BaseException as e:
-            print ('[EROR] Error while deleting media file:', str(e))
-          return
-      else:
-        return imgur_file
-    else:
-      print('[EROR] Could not identify Imgur image/gallery ID in this URL:', img_url)
-      return
-  elif ('gfycat.com' in img_url): # Gfycat
-    gfycat_name = os.path.basename(urllib.parse.urlsplit(img_url).path)
-    client = GfycatClient()
-    gfycat_info = client.query_gfy(gfycat_name)
-    # Download the 2MB version because Tweepy has a 3MB upload limit for GIFs
-    gfycat_url = gfycat_info['gfyItem']['max2mbGif']
-    file_path = IMAGE_DIR + '/' + gfycat_name + '.gif'
-    print('[ OK ] Downloading Gfycat at URL ' + gfycat_url + ' to ' + file_path)
-    gfycat_file = save_file(gfycat_url, file_path)
-    return gfycat_file
-  elif ('giphy.com' in img_url): # Giphy
-    # Working demo of regex: https://regex101.com/r/o8m1kA/2
-    regex = r"https?://((?:.*)giphy\.com/media/|giphy.com/gifs/|i.giphy.com/)(.*-)?(\w+)(/|\n)"
-    m = re.search(regex, img_url, flags=0)
-    if m:
-      # Get the Giphy ID
-      id = m.group(3)
-      # Download the 2MB version because Tweepy has a 3MB upload limit for GIFs
-      giphy_url = 'https://media.giphy.com/media/' + id + '/giphy-downsized.gif'
-      file_path = IMAGE_DIR + '/' + id + '-downsized.gif'
-      print('[ OK ] Downloading Giphy at URL ' + giphy_url + ' to ' + file_path)
-      giphy_file = save_file(giphy_url, file_path)
-      # Check the hash to make sure it's not a GIF saying "This content is not available"
-      # More info: https://github.com/corbindavenport/tootbot/issues/8
-      hash = hashlib.md5(file_as_bytes(open(giphy_file, 'rb'))).hexdigest()
-      if (hash == '59a41d58693283c72d9da8ae0561e4e5'):
-        print('[EROR] Giphy has not processed a downsized GIF version of this link, so it can not be posted')
-        return
-      else:
-        return giphy_file
-    else:
-      print('[EROR] Could not identify Giphy ID in this URL:', img_url)
-      return
-  else:
-    # Check if URL is an image, based on the MIME type
-    image_formats = ('image/png', 'image/jpeg', 'image/gif', 'image/webp')
-    img_site = urlopen(img_url)
-    meta = img_site.info()
-    if meta["content-type"] in image_formats:
-      # URL appears to be an image, so download it
+  if any(s in img_url for s in ('i.redd.it', 'i.reddituploads.com')):  # Reddit-hosted images
       file_name = os.path.basename(urllib.parse.urlsplit(img_url).path)
+      file_extension = os.path.splitext(img_url)[-1].lower()
+      # Fix for issue with i.reddituploads.com links not having a file extension in the URL
+      if not file_extension:
+          file_extension += '.jpg'
+          file_name += '.jpg'
+          img_url += '.jpg'
+      # Download the file
       file_path = IMAGE_DIR + '/' + file_name
-      print('[ OK ] Downloading file at URL ' + img_url + ' to ' + file_path)
+      print('[ OK ] Downloading file at URL ' + img_url + ' to ' +
+            file_path + ', file type identified as ' + file_extension)
+      img = save_file(img_url, file_path)
+      return img
+  elif ('imgur.com' in img_url):  # Imgur
       try:
-        img = save_file(img_url, file_path)
-        return img
+          client = ImgurClient(IMGUR_CLIENT, IMGUR_CLIENT_SECRET)
       except BaseException as e:
-        print ('[EROR] Error while downloading image:', str(e))
-        return
-    else:
-      print ('[EROR] URL does not point to a valid image file.')
-      return
+          print('[EROR] Error while authenticating with Imgur:', str(e))
+          return
+      # Working demo of regex: https://regex101.com/r/G29uGl/2
+      regex = r"(?:.*)imgur\.com(?:\/gallery\/|\/a\/|\/)(.*?)(?:\/.*|\.|$)"
+      m = re.search(regex, img_url, flags=0)
+      if m:
+          # Get the Imgur image/gallery ID
+          id = m.group(1)
+          if any(s in img_url for s in ('/a/', '/gallery/')):  # Gallery links
+              images = client.get_album_images(id)
+              # Only the first image in a gallery is used
+              imgur_url = images[0].link
+          else:  # Single image
+              imgur_url = client.get_image(id).link
+          # If the URL is a GIFV or MP4 link, change it to the GIF version
+          file_extension = os.path.splitext(imgur_url)[-1].lower()
+          if (file_extension == '.gifv'):
+              file_extension = file_extension.replace('.gifv', '.gif')
+              imgur_url = imgur_url.replace('.gifv', '.gif')
+          elif (file_extension == '.mp4'):
+              file_extension = file_extension.replace('.mp4', '.gif')
+              imgur_url = imgur_url.replace('.mp4', '.gif')
+          # Download the image
+          file_path = IMAGE_DIR + '/' + id + file_extension
+          print('[ OK ] Downloading Imgur image at URL ' +
+                imgur_url + ' to ' + file_path)
+          imgur_file = save_file(imgur_url, file_path)
+          # Imgur will sometimes return a single-frame thumbnail instead of a GIF, so we need to check for this
+          if (file_extension == '.gif'):
+              # Open the file using the Pillow library
+              img = Image.open(imgur_file)
+              # Get the MIME type
+              mime = Image.MIME[img.format]
+              if (mime == 'image/gif'):
+                  # Image is indeed a GIF, so it can be posted
+                  img.close()
+                  return imgur_file
+              else:
+                  # Image is not actually a GIF, so don't post it
+                  print(
+                      '[EROR] Imgur has not processed a GIF version of this link, so it can not be posted')
+                  img.close()
+                  # Delete the image
+                  try:
+                      os.remove(imgur_file)
+                  except BaseException as e:
+                      print('[EROR] Error while deleting media file:', str(e))
+                  return
+          else:
+              return imgur_file
+      else:
+          print(
+              '[EROR] Could not identify Imgur image/gallery ID in this URL:', img_url)
+          return
+  elif ('gfycat.com' in img_url):  # Gfycat
+      gfycat_name = os.path.basename(urllib.parse.urlsplit(img_url).path)
+      client = GfycatClient()
+      gfycat_info = client.query_gfy(gfycat_name)
+      # Download the 2MB version because Tweepy has a 3MB upload limit for GIFs
+      gfycat_url = gfycat_info['gfyItem']['max2mbGif']
+      file_path = IMAGE_DIR + '/' + gfycat_name + '.gif'
+      print('[ OK ] Downloading Gfycat at URL ' +
+            gfycat_url + ' to ' + file_path)
+      gfycat_file = save_file(gfycat_url, file_path)
+      return gfycat_file
+  elif ('giphy.com' in img_url):  # Giphy
+      # Working demo of regex: https://regex101.com/r/o8m1kA/2
+      regex = r"https?://((?:.*)giphy\.com/media/|giphy.com/gifs/|i.giphy.com/)(.*-)?(\w+)(/|\n)"
+      m = re.search(regex, img_url, flags=0)
+      if m:
+          # Get the Giphy ID
+          id = m.group(3)
+          # Download the 2MB version because Tweepy has a 3MB upload limit for GIFs
+          giphy_url = 'https://media.giphy.com/media/' + id + '/giphy-downsized.gif'
+          file_path = IMAGE_DIR + '/' + id + '-downsized.gif'
+          print('[ OK ] Downloading Giphy at URL ' +
+                giphy_url + ' to ' + file_path)
+          giphy_file = save_file(giphy_url, file_path)
+          # Check the hash to make sure it's not a GIF saying "This content is not available"
+          # More info: https://github.com/corbindavenport/tootbot/issues/8
+          hash = hashlib.md5(file_as_bytes(
+              open(giphy_file, 'rb'))).hexdigest()
+          if (hash == '59a41d58693283c72d9da8ae0561e4e5'):
+              print(
+                  '[EROR] Giphy has not processed a downsized GIF version of this link, so it can not be posted')
+              return
+          else:
+              return giphy_file
+      else:
+          print('[EROR] Could not identify Giphy ID in this URL:', img_url)
+          return
+  else:
+      # Check if URL is an image, based on the MIME type
+      image_formats = ('image/png', 'image/jpeg', 'image/gif', 'image/webp')
+      img_site = urlopen(img_url)
+      meta = img_site.info()
+      if meta["content-type"] in image_formats:
+          # URL appears to be an image, so download it
+          file_name = os.path.basename(urllib.parse.urlsplit(img_url).path)
+          file_path = IMAGE_DIR + '/' + file_name
+          print('[ OK ] Downloading file at URL ' +
+                img_url + ' to ' + file_path)
+          try:
+              img = save_file(img_url, file_path)
+              return img
+          except BaseException as e:
+              print('[EROR] Error while downloading image:', str(e))
+              return
+      else:
+          print('[EROR] URL does not point to a valid image file.')
+          return
 
 # Function for obtaining static images/GIFs, or MP4 videos if they exist, from popular image hosts
 # This is currently only used for Mastodon posts, because the Tweepy API doesn't support video uploads
-def get_hd_media(img_url, IMGUR_CLIENT, IMGUR_CLIENT_SECRET, submission):
+
+
+def get_hd_media(submission, IMGUR_CLIENT, IMGUR_CLIENT_SECRET):
+  media_url = submission.url
   # Make sure config file exists
   try:
       config = configparser.ConfigParser()
       config.read('config.ini')
   except BaseException as e:
-      print ('[EROR] Error while reading config file:', str(e))
+      print('[EROR] Error while reading config file:', str(e))
       sys.exit()
   # Make sure media folder exists
   IMAGE_DIR = config['MediaSettings']['MediaFolder']
   if not os.path.exists(IMAGE_DIR):
       os.makedirs(IMAGE_DIR)
-      print ('[ OK ] Media folder not found, created a new one')
+      print('[ OK ] Media folder not found, created a new one')
   # Download and save the linked image
-  if any(s in img_url for s in ('i.redd.it', 'i.reddituploads.com')): # Reddit-hosted images
-    file_name = os.path.basename(urllib.parse.urlsplit(img_url).path)
-    file_extension = os.path.splitext(img_url)[-1].lower()
-    # Fix for issue with i.reddituploads.com links not having a file extension in the URL
-    if not file_extension:
-      file_extension += '.jpg'
-      file_name += '.jpg'
-      img_url += '.jpg'
-    # Download the file
-    file_path = IMAGE_DIR + '/' + file_name
-    print('[ OK ] Downloading file at URL ' + img_url + ' to ' + file_path + ', file type identified as ' + file_extension)
-    img = save_file(img_url, file_path)
-    return img
-  elif ('v.redd.it' in img_url): # Reddit video
-    if submission.media:
-      # Get URL for MP4 version of reddit video
-      video_url = submission.media['reddit_video']['fallback_url']
+  if any(s in media_url for s in ('i.redd.it', 'i.reddituploads.com')):  # Reddit-hosted images
+      file_name = os.path.basename(urllib.parse.urlsplit(media_url).path)
+      file_extension = os.path.splitext(media_url)[-1].lower()
+      # Fix for issue with i.reddituploads.com links not having a file extension in the URL
+      if not file_extension:
+          file_extension += '.jpg'
+          file_name += '.jpg'
+          media_url += '.jpg'
       # Download the file
-      file_path = IMAGE_DIR + '/video.mp4'
-      print('[ OK ] Downloading file at URL ' + video_url + ' to ' + file_path)
-      video = save_file(video_url, file_path)
-      return video
-    else:
-      print('[EROR] Reddit API returned no media for this URL:', img_url)
-      return
-  elif ('imgur.com' in img_url): # Imgur
-    try:
-      client = ImgurClient(IMGUR_CLIENT, IMGUR_CLIENT_SECRET)
-    except BaseException as e:
-      print ('[EROR] Error while authenticating with Imgur:', str(e))	
-      return
-    # Working demo of regex: https://regex101.com/r/G29uGl/2
-    regex = r"(?:.*)imgur\.com(?:\/gallery\/|\/a\/|\/)(.*?)(?:\/.*|\.|$)"
-    m = re.search(regex, img_url, flags=0)
-    if m:
-      # Get the Imgur image/gallery ID
-      id = m.group(1)
-      if any(s in img_url for s in ('/a/', '/gallery/')): # Gallery links
-        images = client.get_album_images(id)
-        # Only the first image in a gallery is used
-        imgur_url = images[0].link
-        print (images[0])
-      else: # Single image
-        imgur_url = client.get_image(id).link
-      # If the URL is a GIFV or GIF link, download the MP4 file instead
-      file_extension = os.path.splitext(imgur_url)[-1].lower()
-      if (file_extension == '.gifv'):
-        file_extension = file_extension.replace('.gifv', '.mp4')
-        imgur_url = imgur_url.replace('.gifv', '.mp4')
-      elif (file_extension == '.gif'):
-        file_extension = file_extension.replace('.gif', '.mp4')
-        imgur_url = imgur_url.replace('.gif', '.mp4')
-      # Download the image
-      file_path = IMAGE_DIR + '/' + id + file_extension
-      print('[ OK ] Downloading Imgur image at URL ' + imgur_url + ' to ' + file_path)
-      imgur_file = save_file(imgur_url, file_path)
-      return imgur_file
-    else:
-      print('[EROR] Could not identify Imgur image/gallery ID in this URL:', img_url)
-      return
-  elif ('gfycat.com' in img_url): # Gfycat
-    gfycat_name = os.path.basename(urllib.parse.urlsplit(img_url).path)
-    client = GfycatClient()
-    gfycat_info = client.query_gfy(gfycat_name)
-    # Download the Mp4 version
-    gfycat_url = gfycat_info['gfyItem']['mp4Url']
-    file_path = IMAGE_DIR + '/' + gfycat_name + '.mp4'
-    print('[ OK ] Downloading Gfycat at URL ' + gfycat_url + ' to ' + file_path)
-    gfycat_file = save_file(gfycat_url, file_path)
-    return gfycat_file
-  elif ('giphy.com' in img_url): # Giphy
-    # Working demo of regex: https://regex101.com/r/o8m1kA/2
-    regex = r"https?://((?:.*)giphy\.com/media/|giphy.com/gifs/|i.giphy.com/)(.*-)?(\w+)(/|\n)"
-    m = re.search(regex, img_url, flags=0)
-    if m:
-      # Get the Giphy ID
-      id = m.group(3)
-      # Download the MP4 version of the GIF
-      giphy_url = 'https://media.giphy.com/media/' + id + '/giphy.mp4'
-      file_path = IMAGE_DIR + '/' + id + 'giphy.mp4'
-      print('[ OK ] Downloading Giphy at URL ' + giphy_url + ' to ' + file_path)
-      giphy_file = save_file(giphy_url, file_path)
-      return giphy_file
-    else:
-      print('[EROR] Could not identify Giphy ID in this URL:', img_url)
-      return
-  else:
-    # Check if URL is an image or MP4 file, based on the MIME type
-    image_formats = ('image/png', 'image/jpeg', 'image/gif', 'image/webp', 'video/mp4')
-    img_site = urlopen(img_url)
-    meta = img_site.info()
-    if meta["content-type"] in image_formats:
-      # URL appears to be an image, so download it
-      file_name = os.path.basename(urllib.parse.urlsplit(img_url).path)
       file_path = IMAGE_DIR + '/' + file_name
-      print('[ OK ] Downloading file at URL ' + img_url + ' to ' + file_path)
+      print('[ OK ] Downloading file at URL ' + media_url + ' to ' +
+            file_path + ', file type identified as ' + file_extension)
+      img = save_file(media_url, file_path)
+      return img
+  elif ('v.redd.it' in media_url):  # Reddit video
+      if submission.media:
+          # Get URL for MP4 version of reddit video
+          video_url = submission.media['reddit_video']['fallback_url']
+          # Download the file
+          file_path = IMAGE_DIR + '/video.mp4'
+          print('[ OK ] Downloading file at URL ' +
+                video_url + ' to ' + file_path)
+          video = save_file(video_url, file_path)
+          return video
+      else:
+          print('[EROR] Reddit API returned no media for this URL:', media_url)
+          return
+  elif ('imgur.com' in media_url):  # Imgur
       try:
-        img = save_file(img_url, file_path)
-        return img
+          client = ImgurClient(IMGUR_CLIENT, IMGUR_CLIENT_SECRET)
       except BaseException as e:
-        print ('[EROR] Error while downloading image:', str(e))
-        return
-    else:
-      print ('[EROR] URL does not point to a valid image file.')
-      return
+          print('[EROR] Error while authenticating with Imgur:', str(e))
+          return
+      # Working demo of regex: https://regex101.com/r/G29uGl/2
+      regex = r"(?:.*)imgur\.com(?:\/gallery\/|\/a\/|\/)(.*?)(?:\/.*|\.|$)"
+      m = re.search(regex, media_url, flags=0)
+      if m:
+          # Get the Imgur image/gallery ID
+          id = m.group(1)
+          if any(s in media_url for s in ('/a/', '/gallery/')):  # Gallery links
+              images = client.get_album_images(id)
+              # Only the first image in a gallery is used
+              imgur_url = images[0].link
+              print(images[0])
+          else:  # Single image
+              imgur_url = client.get_image(id).link
+          # If the URL is a GIFV link, download the actual MP4 file
+          file_extension = os.path.splitext(imgur_url)[-1].lower()
+          if (file_extension == '.gifv'):
+              file_extension = file_extension.replace('.gifv', '.mp4')
+              imgur_url = imgur_url.replace('.gifv', '.mp4')
+          # Download the image
+          file_path = IMAGE_DIR + '/' + id + file_extension
+          print('[ OK ] Downloading Imgur image at URL ' +
+                imgur_url + ' to ' + file_path)
+          imgur_file = save_file(imgur_url, file_path)
+          return imgur_file
+      else:
+          print(
+              '[EROR] Could not identify Imgur image/gallery ID in this URL:', media_url)
+          return
+  elif ('gfycat.com' in media_url):  # Gfycat
+      gfycat_name = os.path.basename(urllib.parse.urlsplit(media_url).path)
+      client = GfycatClient()
+      gfycat_info = client.query_gfy(gfycat_name)
+      # Download the Mp4 version
+      gfycat_url = gfycat_info['gfyItem']['mp4Url']
+      file_path = IMAGE_DIR + '/' + gfycat_name + '.mp4'
+      print('[ OK ] Downloading Gfycat at URL ' +
+            gfycat_url + ' to ' + file_path)
+      gfycat_file = save_file(gfycat_url, file_path)
+      return gfycat_file
+  elif ('giphy.com' in media_url):  # Giphy
+      # Working demo of regex: https://regex101.com/r/o8m1kA/2
+      regex = r"https?://((?:.*)giphy\.com/media/|giphy.com/gifs/|i.giphy.com/)(.*-)?(\w+)(/|\n)"
+      m = re.search(regex, media_url, flags=0)
+      if m:
+          # Get the Giphy ID
+          id = m.group(3)
+          # Download the MP4 version of the GIF
+          giphy_url = 'https://media.giphy.com/media/' + id + '/giphy.mp4'
+          file_path = IMAGE_DIR + '/' + id + 'giphy.mp4'
+          print('[ OK ] Downloading Giphy at URL ' +
+                giphy_url + ' to ' + file_path)
+          giphy_file = save_file(giphy_url, file_path)
+          return giphy_file
+      else:
+          print('[EROR] Could not identify Giphy ID in this URL:', media_url)
+          return
+  else:
+      # Check if URL is an image or MP4 file, based on the MIME type
+      image_formats = ('image/png', 'image/jpeg',
+                        'image/gif', 'image/webp', 'video/mp4')
+      img_site = urlopen(media_url)
+      meta = img_site.info()
+      if meta["content-type"] in image_formats:
+          # URL appears to be an image, so download it
+          file_name = os.path.basename(urllib.parse.urlsplit(media_url).path)
+          file_path = IMAGE_DIR + '/' + file_name
+          print('[ OK ] Downloading file at URL ' +
+                media_url + ' to ' + file_path)
+          try:
+              img = save_file(media_url, file_path)
+              return img
+          except BaseException as e:
+              print('[EROR] Error while downloading image:', str(e))
+              return
+      else:
+          print('[EROR] URL does not point to a valid image file.')
+          return

--- a/getmedia.py
+++ b/getmedia.py
@@ -81,11 +81,14 @@ def get_media(img_url, IMGUR_CLIENT, IMGUR_CLIENT_SECRET):
         imgur_url = images[0].link
       else: # Single image
         imgur_url = client.get_image(id).link
-      # If the URL is a GIFV link, change it to a GIF
+      # If the URL is a GIFV or MP4 link, change it to the GIF version
       file_extension = os.path.splitext(imgur_url)[-1].lower()
       if (file_extension == '.gifv'):
         file_extension = file_extension.replace('.gifv', '.gif')
-        img_url = imgur_url.replace('.gifv', '.gif')
+        imgur_url = imgur_url.replace('.gifv', '.gif')
+      elif (file_extension == '.mp4'):
+        file_extension = file_extension.replace('.mp4', '.gif')
+        imgur_url = imgur_url.replace('.mp4', '.gif')
       # Download the image
       file_path = IMAGE_DIR + '/' + id + file_extension
       print('[ OK ] Downloading Imgur image at URL ' + imgur_url + ' to ' + file_path)

--- a/tootbot-heroku.py
+++ b/tootbot-heroku.py
@@ -63,8 +63,7 @@ def tweet_creator(subreddit_info):
                 mastodon_post = submission.title[:mastodon_max_title_length] + \
                     '... ' + hashtag_string + submission.shortlink
             # Create dict
-            post_dict[submission.id] = [twitter_post, mastodon_post,
-                                        submission.url, submission.id, submission.over_18]
+            post_dict[submission.id] = [twitter_post, mastodon_post, submission.url, submission.id, submission.over_18, submission]
     return post_dict
 
 

--- a/tootbot-heroku.py
+++ b/tootbot-heroku.py
@@ -104,8 +104,8 @@ def make_post(post_dict):
             if POST_TO_TWITTER:
                 media_file = get_media(post_dict[post].url, IMGUR_CLIENT, IMGUR_CLIENT_SECRET)
             # Download Mastodon-compatible version of media file (static image or MP4 file)
-            if MASTODON_INSTANCE_DOMAIN:
-                hd_media_file = get_hd_media(post_dict[post].url, IMGUR_CLIENT, IMGUR_CLIENT_SECRET, post_dict[post])
+            #if MASTODON_INSTANCE_DOMAIN:
+            #    hd_media_file = get_hd_media(post_dict[post], IMGUR_CLIENT, IMGUR_CLIENT_SECRET)
             # Post on Twitter
             if POST_TO_TWITTER:
                 # Make sure the post contains media, if MEDIA_POSTS_ONLY in config is set to True
@@ -126,7 +126,7 @@ def make_post(post_dict):
                             # Clean up media file
                             try:
                                 os.remove(media_file)
-                                print('[ OK ] Deleted media file at ' + media_file)
+                                print('[ OK ] Deleted media file at', media_file)
                             except BaseException as e:
                                 print('[EROR] Error while deleting media file:', str(e))
                         else:

--- a/tootbot-heroku.py
+++ b/tootbot-heroku.py
@@ -14,7 +14,7 @@ import redis
 from mastodon import Mastodon
 from getmedia import get_media
 
-def tweet_creator(subreddit_info):
+def get_reddit_posts(subreddit_info):
     post_dict = {}
     print('[ OK ] Getting posts from Reddit...')
     for submission in subreddit_info.hot(limit=POST_LIMIT):
@@ -52,18 +52,18 @@ def tweet_creator(subreddit_info):
                 len(submission.shortlink) - len(hashtag_string) - 1
             # Create contents of the Twitter post
             if len(submission.title) < twitter_max_title_length:
-                twitter_post = submission.title + ' ' + hashtag_string + submission.shortlink
+                twitter_caption = submission.title + ' ' + hashtag_string + submission.shortlink
             else:
-                twitter_post = submission.title[:twitter_max_title_length] + \
+                twitter_caption = submission.title[:twitter_max_title_length] + \
                     '... ' + hashtag_string + submission.shortlink
             # Create contents of the Mastodon post
             if len(submission.title) < mastodon_max_title_length:
-                mastodon_post = submission.title + ' ' + hashtag_string + submission.shortlink
+                mastodon_caption = submission.title + ' ' + hashtag_string + submission.shortlink
             else:
-                mastodon_post = submission.title[:mastodon_max_title_length] + \
+                mastodon_caption = submission.title[:mastodon_max_title_length] + \
                     '... ' + hashtag_string + submission.shortlink
             # Create dict
-            post_dict[submission.id] = [twitter_post, mastodon_post, submission.url, submission.id, submission.over_18, submission]
+            post_dict[submission.id] = [twitter_caption, mastodon_caption, submission.url, submission.id, submission.over_18, submission]
     return post_dict
 
 
@@ -234,7 +234,7 @@ if POST_TO_MASTODON is True:
 # Run the main script
 while True:
     subreddit = setup_connection_reddit(SUBREDDIT_TO_MONITOR)
-    post_dict = tweet_creator(subreddit)
+    post_dict = get_reddit_posts(subreddit)
     make_post(post_dict)
     print('[ OK ] Sleeping for', DELAY_BETWEEN_TWEETS, 'seconds')
     time.sleep(DELAY_BETWEEN_TWEETS)

--- a/tootbot-heroku.py
+++ b/tootbot-heroku.py
@@ -148,7 +148,7 @@ try:
     with urllib.request.urlopen("https://raw.githubusercontent.com/corbindavenport/tootbot/update-check/current-version.txt") as url:
         s = url.read()
         new_version = s.decode("utf-8").rstrip()
-        current_version = 2.3  # Current version of script
+        current_version = 2.4  # Current version of script
         if (current_version < float(new_version)):
             print('[WARN] A new version of Tootbot (' + str(new_version) + ') is available! (you have ' + str(current_version) + ')')
             print('[WARN] Get the latest update from here: https://github.com/corbindavenport/tootbot/releases')

--- a/tootbot-heroku.py
+++ b/tootbot-heroku.py
@@ -139,7 +139,7 @@ def make_post(post_dict):
                         # Log the post anyways
                         log_post(post_id)
                 else:
-                    print('[ OK ] Ignoring', post_id, 'because non-media posts are disabled or there was not a valid media file downloaded')
+                    print('[WARN] Twitter: Ignoring', post_id, 'because non-media posts are disabled or the media file was not found')
             
             # Post on Mastodon
             #TODO: Mastodon support

--- a/tootbot.py
+++ b/tootbot.py
@@ -15,7 +15,7 @@ from mastodon import Mastodon
 from getmedia import get_media
 from getmedia import get_hd_media
 
-def tweet_creator(subreddit_info):
+def get_reddit_posts(subreddit_info):
     post_dict = {}
     print('[ OK ] Getting posts from Reddit...')
     for submission in subreddit_info.hot(limit=POST_LIMIT):
@@ -53,18 +53,18 @@ def tweet_creator(subreddit_info):
                 len(submission.shortlink) - len(hashtag_string) - 1
             # Create contents of the Twitter post
             if len(submission.title) < twitter_max_title_length:
-                twitter_post = submission.title + ' ' + hashtag_string + submission.shortlink
+                twitter_caption = submission.title + ' ' + hashtag_string + submission.shortlink
             else:
-                twitter_post = submission.title[:twitter_max_title_length] + \
+                twitter_caption = submission.title[:twitter_max_title_length] + \
                     '... ' + hashtag_string + submission.shortlink
             # Create contents of the Mastodon post
             if len(submission.title) < mastodon_max_title_length:
-                mastodon_post = submission.title + ' ' + hashtag_string + submission.shortlink
+                mastodon_caption = submission.title + ' ' + hashtag_string + submission.shortlink
             else:
-                mastodon_post = submission.title[:mastodon_max_title_length] + \
+                mastodon_caption = submission.title[:mastodon_max_title_length] + \
                     '... ' + hashtag_string + submission.shortlink
             # Create dict
-            post_dict[submission.id] = [twitter_post, mastodon_post, submission.url, submission.id, submission.over_18, submission]
+            post_dict[submission.id] = [twitter_caption, mastodon_caption, submission.url, submission.id, submission.over_18, submission]
     return post_dict
 
 
@@ -434,7 +434,7 @@ while True:
     # Continue with script
     try:
         subreddit = setup_connection_reddit(SUBREDDIT_TO_MONITOR)
-        post_dict = tweet_creator(subreddit)
+        post_dict = get_reddit_posts(subreddit)
         make_post(post_dict)
     except BaseException as e:
         print('[EROR] Error in main process:', str(e))

--- a/tootbot.py
+++ b/tootbot.py
@@ -13,7 +13,7 @@ import distutils.core
 import itertools
 from mastodon import Mastodon
 from getmedia import get_media
-
+from getmedia import get_hd_media
 
 def tweet_creator(subreddit_info):
     post_dict = {}
@@ -102,12 +102,16 @@ def make_post(post_dict):
         # Grab post details from dictionary
         post_id = post_dict[post][3]
         if not duplicate_check(post_id):  # Make sure post is not a duplicate
-            file_path = get_media(
-                post_dict[post][2], IMGUR_CLIENT, IMGUR_CLIENT_SECRET)
-            # Make sure the post contains media (if it doesn't, then file_path would be blank)
-            if (((MEDIA_POSTS_ONLY is True) and (file_path)) or (MEDIA_POSTS_ONLY is False)):
-                # Post on Twitter
-                if POST_TO_TWITTER:
+            # Download Twitter-compatible version of media file (static image or GIF under 3MB)
+            if POST_TO_TWITTER:
+                media_file = get_media(post_dict[post][2], IMGUR_CLIENT, IMGUR_CLIENT_SECRET)
+            # Download Mastodon-compatible version of media file (static image or MP4 file)
+            if MASTODON_INSTANCE_DOMAIN:
+                hd_media_file = get_hd_media(post_dict[post][2], IMGUR_CLIENT, IMGUR_CLIENT_SECRET)
+            # Post on Twitter
+            if POST_TO_TWITTER:
+                # Make sure the post contains media, if MEDIA_POSTS_ONLY in config is set to True
+                if (((MEDIA_POSTS_ONLY is True) and media_file) or (MEDIA_POSTS_ONLY is False)):
                     try:
                         auth = tweepy.OAuthHandler(
                             CONSUMER_KEY, CONSUMER_SECRET)
@@ -115,47 +119,55 @@ def make_post(post_dict):
                             ACCESS_TOKEN, ACCESS_TOKEN_SECRET)
                         twitter = tweepy.API(auth)
                         # Post the tweet
-                        if (file_path):
+                        if (media_file):
                             print(
                                 '[ OK ] Posting this on Twitter with media attachment:', post_dict[post][0])
                             tweet = twitter.update_with_media(
-                                filename=file_path, status=post_dict[post][0])
+                                filename=media_file, status=post_dict[post][0])
+                            # Clean up media file
+                            try:
+                                os.remove(media_file)
+                                print('[ OK ] Deleted media file at ' + media_file)
+                            except BaseException as e:
+                                print('[EROR] Error while deleting media file:', str(e))
                         else:
-                            print('[ OK ] Posting this on Twitter:',
-                                  post_dict[post][0])
-                            tweet = twitter.update_status(
-                                status=post_dict[post][0])
+                            print('[ OK ] Posting this on Twitter:',post_dict[post][0])
+                            tweet = twitter.update_status(status=post_dict[post][0])
                         # Log the tweet
-                        log_post(post_id, 'https://twitter.com/' +
-                                 twitter_username + '/status/' + tweet.id_str + '/')
+                        log_post(post_id, 'https://twitter.com/' + twitter_username + '/status/' + tweet.id_str + '/')
                     except BaseException as e:
                         print('[EROR] Error while posting tweet:', str(e))
                         # Log the post anyways
-                        log_post(post_id,
-                                 'Error while posting tweet: ' + str(e))
-                # Post on Mastodon
-                if MASTODON_INSTANCE_DOMAIN:
+                        log_post(post_id, 'Error while posting tweet: ' + str(e))
+                else:
+                    print('[ OK ] Ignoring', post_id, 'because non-media posts are disabled or there was not a valid media file downloaded')
+            
+            # Post on Mastodon
+            if MASTODON_INSTANCE_DOMAIN:
+                # Make sure the post contains media, if MEDIA_POSTS_ONLY in config is set to True
+                if (((MEDIA_POSTS_ONLY is True) and hd_media_file) or (MEDIA_POSTS_ONLY is False)):
                     try:
                         # Post the toot
-                        if (file_path):
+                        if (hd_media_file):
                             print(
                                 '[ OK ] Posting this on Mastodon with media attachment:', post_dict[post][1])
-                            media = mastodon.media_post(
-                                file_path, mime_type=None)
+                            media = mastodon.media_post(hd_media_file, mime_type=None)
                             # If the post is marked as NSFW on Reddit, force sensitive media warning for images
                             if (post_dict[post][4] == True):
-                                toot = mastodon.status_post(post_dict[post][1], media_ids=[
-                                                            media], spoiler_text='NSFW')
+                                toot = mastodon.status_post(post_dict[post][1], media_ids=[media], spoiler_text='NSFW')
                             else:
-                                toot = mastodon.status_post(post_dict[post][1], media_ids=[
-                                                            media], sensitive=MASTODON_SENSITIVE_MEDIA)
+                                toot = mastodon.status_post(post_dict[post][1], media_ids=[media], sensitive=MASTODON_SENSITIVE_MEDIA)
+                            # Clean up media file
+                            try:
+                                os.remove(hd_media_file)
+                                print('[ OK ] Deleted media file at ' + hd_media_file)
+                            except BaseException as e:
+                                print('[EROR] Error while deleting media file:', str(e))
                         else:
-                            print('[ OK ] Posting this on Mastodon:',
-                                  post_dict[post][1])
+                            print('[ OK ] Posting this on Mastodon:', post_dict[post][1])
                             # Add NSFW warning for Reddit posts marked as NSFW
                             if (post_dict[post][4] == True):
-                                toot = mastodon.status_post(
-                                    post_dict[post][1], spoiler_text='NSFW')
+                                toot = mastodon.status_post(post_dict[post][1], spoiler_text='NSFW')
                             else:
                                 toot = mastodon.status_post(post_dict[post][1])
                         # Log the toot
@@ -163,21 +175,13 @@ def make_post(post_dict):
                     except BaseException as e:
                         print('[EROR] Error while posting toot:', str(e))
                         # Log the post anyways
-                        log_post(post_dict[post][3],
-                                 'Error while posting toot: ' + str(e))
-                # Cleanup media file
-                if (file_path):
-                    try:
-                        os.remove(file_path)
-                        print('[ OK ] Deleted media file at ' + file_path)
-                    except BaseException as e:
-                        print('[EROR] Error while deleting media file:', str(e))
-                # Go to sleep
-                print('[ OK ] Sleeping for', DELAY_BETWEEN_TWEETS, 'seconds')
-                time.sleep(DELAY_BETWEEN_TWEETS)
-            else:
-                print('[ OK ] Ignoring', post_id,
-                      'because non-media posts are disabled or there was not a valid media file downloaded')
+                        log_post(post_dict[post][3],'Error while posting toot: ' + str(e))
+                else:
+                    print('[ OK ] Ignoring', post_id, 'because non-media posts are disabled or there was not a valid media file downloaded')
+            
+            # Go to sleep
+            print('[ OK ] Sleeping for', DELAY_BETWEEN_TWEETS, 'seconds')
+            time.sleep(DELAY_BETWEEN_TWEETS)
         else:
             print('[ OK ] Ignoring', post_id, 'because it was already posted')
 

--- a/tootbot.py
+++ b/tootbot.py
@@ -187,7 +187,7 @@ try:
     with urllib.request.urlopen("https://raw.githubusercontent.com/corbindavenport/tootbot/update-check/current-version.txt") as url:
         s = url.read()
         new_version = s.decode("utf-8").rstrip()
-        current_version = 2.3  # Current version of script
+        current_version = 2.4  # Current version of script
         if (current_version < float(new_version)):
             print('[WARN] A new version of Tootbot (' + str(new_version) + ') is available! (you have ' + str(current_version) + ')')
             print('[WARN] Get the latest update from here: https://github.com/corbindavenport/tootbot/releases')

--- a/tootbot.py
+++ b/tootbot.py
@@ -64,8 +64,7 @@ def tweet_creator(subreddit_info):
                 mastodon_post = submission.title[:mastodon_max_title_length] + \
                     '... ' + hashtag_string + submission.shortlink
             # Create dict
-            post_dict[submission.id] = [twitter_post, mastodon_post,
-                                        submission.url, submission.id, submission.over_18]
+            post_dict[submission.id] = [twitter_post, mastodon_post, submission.url, submission.id, submission.over_18, submission]
     return post_dict
 
 
@@ -107,7 +106,7 @@ def make_post(post_dict):
                 media_file = get_media(post_dict[post][2], IMGUR_CLIENT, IMGUR_CLIENT_SECRET)
             # Download Mastodon-compatible version of media file (static image or MP4 file)
             if MASTODON_INSTANCE_DOMAIN:
-                hd_media_file = get_hd_media(post_dict[post][2], IMGUR_CLIENT, IMGUR_CLIENT_SECRET)
+                hd_media_file = get_hd_media(post_dict[post][2], IMGUR_CLIENT, IMGUR_CLIENT_SECRET, post_dict[post][5])
             # Post on Twitter
             if POST_TO_TWITTER:
                 # Make sure the post contains media, if MEDIA_POSTS_ONLY in config is set to True

--- a/tootbot.py
+++ b/tootbot.py
@@ -146,7 +146,7 @@ def make_post(post_dict):
                         # Log the post anyways
                         log_post(post_id, 'Error while posting tweet: ' + str(e))
                 else:
-                    print('[ OK ] Ignoring', post_id, 'because non-media posts are disabled or there was not a valid media file downloaded')
+                    print('[WARN] Twitter: Ignoring', post_id, 'because non-media posts are disabled or the media file was not found')
             
             # Post on Mastodon
             if MASTODON_INSTANCE_DOMAIN:
@@ -185,7 +185,7 @@ def make_post(post_dict):
                         # Log the post anyways
                         log_post(post_id,'Error while posting toot: ' + str(e))
                 else:
-                    print('[ OK ] Ignoring', post_id, 'because non-media posts are disabled or there was not a valid media file downloaded')
+                    print('[WARN] Mastodon: Ignoring', post_id, 'because non-media posts are disabled or the media file was not found')
             
             # Go to sleep
             print('[ OK ] Sleeping for', DELAY_BETWEEN_TWEETS, 'seconds')

--- a/tootbot.py
+++ b/tootbot.py
@@ -112,7 +112,7 @@ def make_post(post_dict):
                 media_file = get_media(post_dict[post].url, IMGUR_CLIENT, IMGUR_CLIENT_SECRET)
             # Download Mastodon-compatible version of media file (static image or MP4 file)
             if MASTODON_INSTANCE_DOMAIN:
-                hd_media_file = get_hd_media(post_dict[post].url, IMGUR_CLIENT, IMGUR_CLIENT_SECRET, post_dict[post])
+                hd_media_file = get_hd_media(post_dict[post], IMGUR_CLIENT, IMGUR_CLIENT_SECRET)
             # Post on Twitter
             if POST_TO_TWITTER:
                 # Make sure the post contains media, if MEDIA_POSTS_ONLY in config is set to True
@@ -133,7 +133,7 @@ def make_post(post_dict):
                             # Clean up media file
                             try:
                                 os.remove(media_file)
-                                print('[ OK ] Deleted media file at ' + media_file)
+                                print('[ OK ] Deleted media file at', media_file)
                             except BaseException as e:
                                 print('[EROR] Error while deleting media file:', str(e))
                         else:
@@ -168,7 +168,7 @@ def make_post(post_dict):
                             # Clean up media file
                             try:
                                 os.remove(hd_media_file)
-                                print('[ OK ] Deleted media file at ' + hd_media_file)
+                                print('[ OK ] Deleted media file at', hd_media_file)
                             except BaseException as e:
                                 print('[EROR] Error while deleting media file:', str(e))
                         else:


### PR DESCRIPTION
**IMPORTANT:** If you currently operate a Twitter bot, you have to apply for a Developer account or you will eventually lose API access. It's free and doesn't take much time. Full instructions are [here](https://github.com/corbindavenport/tootbot/wiki/Migrating-existing-Twitter-bots-to-the-new-API-Dashboard).

## What's New

* Tootbot now uploads full-quality MP4 versions of GIFs when posting to Mastodon. This feature currently works with links from Imgur, Gfycat, and Giphy. (#3)
* Reddit video links (v.redd.it) are now supported by Tootbot, but only when posting to Mastodon. (#74) Video upload support for Twitter may be possible at some point in the future, see #75.
* The codebase has been significantly reworked, with a focus on making the code easier to understand.
* Console messages have been improved.

## Update instructions (local install)

No special steps are required when updating from Tootbot 2.1-2.3. Just replace `tootbot.py` and `getmedia.py` with the latest versions.

## Update instructions (Heroku)

See [the wiki](https://github.com/corbindavenport/tootbot/wiki/Updating-Tootbot-on-Heroku) for help updating an existing Heroku installation. Since the Heroku version of Tootbot currently only supports Twitter, and there are no major improvements for posting to Twitter in this release, there's not a major reason to upgrade existing Heroku bots at this time.